### PR TITLE
fix: remove duplicate 'a' attribute from FAQ nav link

### DIFF
--- a/about-page.html
+++ b/about-page.html
@@ -18,7 +18,7 @@
       <ul>
         <li><a href="index.html">Home</a></li>
         <li><a href="about-page.html">About</a></li>
-        <li><a a href="faq.html">FAQ</a></li>
+        <li><a href="faq.html">FAQ</a></li>
         <li id="link-myWorkouts"><a href="my-workouts.html">My Workouts</a></li>
       </ul>
     </header>

--- a/faq.html
+++ b/faq.html
@@ -18,7 +18,7 @@
       <ul>
         <li><a href="index.html">Home</a></li>
         <li><a href="about-page.html">About</a></li>
-        <li><a a href="faq.html">FAQ</a></li>
+        <li><a href="faq.html">FAQ</a></li>
         <li id="link-myWorkouts"><a href="my-workouts.html">My Workouts</a></li>
       </ul>
     </header>

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
       <ul aria-label="Navigation List">
         <li><a href="index.html">Home</a></li>
         <li><a href="about-page.html">About</a></li>
-        <li><a a href="faq.html">FAQ</a></li>
+        <li><a href="faq.html">FAQ</a></li>
         <li id="link-myWorkouts"><a href="my-workouts.html">My Workouts</a></li>
       </ul>
     </header>

--- a/my-workouts.html
+++ b/my-workouts.html
@@ -19,7 +19,7 @@
       <ul>
         <li><a href="index.html">Home</a></li>
         <li><a href="about-page.html">About</a></li>
-        <li><a a href="faq.html">FAQ</a></li>
+        <li><a href="faq.html">FAQ</a></li>
         <li id="link-myWorkouts"><a href="my-workouts.html">My Workouts</a></li>
       </ul>
     </header>

--- a/time-page.html
+++ b/time-page.html
@@ -18,7 +18,7 @@
       <ul>
         <li><a href="index.html">Home</a></li>
         <li><a href="about-page.html">About</a></li>
-        <li><a a href="faq.html">FAQ</a></li>
+        <li><a href="faq.html">FAQ</a></li>
         <li id="link-myWorkouts"><a href="my-workouts.html">My Workouts</a></li>
       </ul>
     </header>

--- a/workout-page.html
+++ b/workout-page.html
@@ -18,7 +18,7 @@
       <ul>
         <li><a href="index.html">Home</a></li>
         <li><a href="about-page.html">About</a></li>
-        <li><a a href="faq.html">FAQ</a></li>
+        <li><a href="faq.html">FAQ</a></li>
         <li id="link-myWorkouts"><a href="my-workouts.html">My Workouts</a></li>
       </ul>
     </header>


### PR DESCRIPTION
## Summary

- Removes the duplicate `a` attribute from `<a a href="faq.html">` in all 6 HTML files
- The double attribute is invalid HTML and caused the FAQ nav link to be parsed incorrectly by browsers

## Test plan

- [ ] Verify FAQ nav link works on all pages