### PR TITLE
fix: remove debug console.log from handleType

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -102,7 +102,6 @@ function handleType(event) {
   let woType = document.getElementsByName('radio');
   for (let i = 0; i < woType.length; i++) {
     if (woType[i].checked) {
-      console.log(woType[i].value);
       let workoutType = woType[i].value;
       let workoutObject = {
         type: workoutType


### PR DESCRIPTION
## Summary

- Removes leftover `console.log(woType[i].value)` from `handleType` in `app.js`
- Was printing the selected workout type to the browser console on every form interaction

## Test plan

- [ ] Confirm no console output when selecting a workout type