### PR TITLE
fix: add missing px unit to h3 font-size in workout-page.css

### DIFF
--- a/css/workout-page.css
+++ b/css/workout-page.css
@@ -26,7 +26,7 @@ h3 {
   font-weight: 650;
   margin-top: 50px;
   color: var(--primary-darkBlue);
-  font-size: 18;
+  font-size: 18px;
   text-align: left;
   padding-left: 25px;
 }


### PR DESCRIPTION
## Summary

- Adds the missing `px` unit to the `h3` font-size rule in `workout-page.css`
- Unitless values (except `0`) are invalid in CSS and are silently ignored, causing the heading to fall back to the browser default size

## Test plan

- [ ] Verify h3 headings on the workout page render at the intended size