### PR TITLE
fix: replace hardcoded button colors with CSS variables

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -120,10 +120,10 @@ input{
   width: 225px;
   font-size: 16px;
   font-weight: 600;
-  color: #06D6A0;
+  color: var(--secondary-green);
   border-radius: 30px;
-  border-color: #06D6A0;
-  background-color: #C1F5E7;
+  border-color: var(--secondary-green);
+  background-color: var(--secondary-green-light);
 }
 
 #next-btn:hover{

--- a/css/style.css
+++ b/css/style.css
@@ -9,6 +9,7 @@
   --secondary-white: #FCFCFC;
   --secondary-grey: #E0E2E6;
   --secondary-green: #06d6a0;
+  --secondary-green-light: #C1F5E7;
   --secondary-green-rgb: 6,214,160;
   font-family: 'Montserrat', sans-serif;
   color:var(--primary-darkBlue);

--- a/css/workout-page.css
+++ b/css/workout-page.css
@@ -64,8 +64,8 @@ ul {
   width: 225px;
   font-size: 16px;
   font-weight: 600;
-  color: #06D6A0;
+  color: var(--secondary-green);
   border-radius: 30px;
-  border-color: #06D6A0;
-  background-color: #C1F5E7;
+  border-color: var(--secondary-green);
+  background-color: var(--secondary-green-light);
 }


### PR DESCRIPTION
## Summary

- Replaces magic hex values `#06D6A0` and `#C1F5E7` in `index.css` and `workout-page.css` with `var(--secondary-green)` and `var(--secondary-green-light)`
- Adds `--secondary-green-light` variable to `style.css`
- Colors are now defined in one place, making future theme changes easier

## Test plan

- [ ] Verify button colors appear unchanged on index and workout pages