### PR TITLE
fix: correct invalid comma-separated grid-template-columns

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -21,7 +21,7 @@ min-height:50vh;
 
 #grid-wrapper{
   display: grid;
-  grid-template-columns: 1fr,1fr,1fr,1fr;
+  grid-template-columns: repeat(4, 1fr);
   grid-auto-rows: minmax(100px,auto);
 
 }


### PR DESCRIPTION
## Summary

- Changes `grid-template-columns: 1fr,1fr,1fr,1fr` to `repeat(4, 1fr)` in `style.css`
- Comma-separated values are invalid for `grid-template-columns`; the declaration was being silently ignored by browsers, so the grid layout was broken

## Test plan

- [ ] Verify the 4-column grid layout renders correctly