### PR TITLE
fix: change quote section background-size from auto to cover

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -9,7 +9,7 @@ main{
   min-height: 16em;
   width:100%;
   background-color: var(--secondary-grey);
-  background-size: auto;
+  background-size: cover;
   background-position: 50% 65%;
   background-repeat: no-repeat; 
 }


### PR DESCRIPTION
## Summary

- Changes `background-size: auto` to `background-size: cover` on the quote section in `index.css`
- `auto` rendered the hero image at its natural size; `cover` makes it fill the banner as intended

## Test plan

- [ ] Verify the quote section background image fills the banner on the index page