### PR TITLE
feat: add meta description tag to all pages

### DIFF
--- a/about-page.html
+++ b/about-page.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="About Take Ten — meet the team behind the workout generator app.">
   <title>Take Ten - About</title>
   <link rel="stylesheet" href="css/reset.css">
   <link rel="stylesheet" href="css/about.css">

--- a/faq.html
+++ b/faq.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Take Ten FAQ — frequently asked questions about the Take Ten workout generator app.">
   <title>Take Ten - FAQ</title>
   <link rel="stylesheet" href="css/reset.css">
   <link rel="stylesheet" href="css/FAQ.css">

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Take Ten — generate a quick workout in 10, 30, 45, or 60 minutes. No equipment needed.">
   <title>Take Ten</title>
   <link rel="stylesheet" href="css/reset.css">
   <link rel="stylesheet" href="css/style.css">

--- a/my-workouts.html
+++ b/my-workouts.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Take Ten — view your past workout history stored locally on your device.">
   <title>Take Ten - My Workouts</title>
   <link rel="stylesheet" href="css/reset.css">
   <link rel="stylesheet" href="css/style.css">

--- a/time-page.html
+++ b/time-page.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Take Ten — choose how much time you have and generate your workout.">
   <title>Take Ten - Time Select</title>
   <link rel="stylesheet" href="css/reset.css">
   <link rel="stylesheet" href="css/style.css">

--- a/workout-page.html
+++ b/workout-page.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Take Ten — your generated workout for today. No equipment needed.">
   <title>Take Ten - Workout</title>
   <link rel="stylesheet" href="css/reset.css">
   <link rel="stylesheet" href="css/style.css">


### PR DESCRIPTION
## Summary

- Adds a unique `<meta name="description">` tag to all 6 HTML pages
- These were entirely absent; descriptions are used by search engines and social sharing previews

## Test plan

- [ ] Verify meta descriptions appear in page source for all 6 pages